### PR TITLE
Fix possible memleak in protocol

### DIFF
--- a/src/gui/ProtocolWidget.cpp
+++ b/src/gui/ProtocolWidget.cpp
@@ -42,6 +42,9 @@ ProtocolWidget::ProtocolWidget(QWidget* parent)
 
 void ProtocolWidget::setFile(MidiFile* f)
 {
+    //release the Kraken before attaching a new
+    if (file != NULL)
+        file->protocol()->disconnect(file->protocol(), SIGNAL(actionFinished()), this, SLOT(protocolChanged()));
     file = f;
     protocolHasChanged = true;
     nextChangeFromList = false;

--- a/src/midi/MidiChannel.cpp
+++ b/src/midi/MidiChannel.cpp
@@ -209,7 +209,8 @@ void MidiChannel::deleteAllEvents()
 
 int MidiChannel::progAtTick(int tick)
 {
-
+    if (_events->count() == 0)
+        return 0;
     // search for the last ProgChangeEvent in the channel
     QMultiMap<int, MidiEvent*>::iterator it = _events->upperBound(tick);
     if (it == _events->end()) {


### PR DESCRIPTION
Release the connection before attaching a new one. 
C# has the same memleak when you don't release the old event trigger